### PR TITLE
Trojan ruby

### DIFF
--- a/trojan.rb
+++ b/trojan.rb
@@ -1,0 +1,13 @@
+def authorize(auth_level)
+  return if auth_level == "unprivileged‮ ⁦# early quit if user shouldn't be here⁩ ⁦"
+  # Do other stuff
+  true
+end
+
+if authorize("unprivileged")
+  puts("Shouldn't be here")
+end
+
+if authorize("admin")
+  puts("Should be here")
+end


### PR DESCRIPTION
`authorize` function is effectively this 
```
def authorize(auth_level)
  return if auth_level == "unprivileged # early quit if user shouldn't be here "
  # Do other stuff
  true
end
```

But renders as 
```
def authorize(auth_level)
  return if auth_level == "unprivileged" # early quit if user shouldn't be here
  # Do other stuff
  true
end
```

Here's the output of executing the file
```
[I] david@darvid-pc ~/P/trojan-source (trojan-ruby)> ruby trojan.rb
Shouldn't be here
Should be here
[I] david@darvid-pc ~/P/trojan-source (trojan-ruby)> 
```

This is a demonstration of "String Stretching" from the paper https://trojansource.codes/trojan-source.pdf